### PR TITLE
Support LinuxArm64

### DIFF
--- a/Source/web3Unreal/web3Unreal.Build.cs
+++ b/Source/web3Unreal/web3Unreal.Build.cs
@@ -16,12 +16,9 @@ public class web3Unreal : ModuleRules
 			return Path.Combine(ThirdPartyPath,"lib", "libsecp256k1.lib");
 		}
 
-		if (Target.Platform == UnrealTargetPlatform.Linux)
-		{
-			return Path.Combine(ThirdPartyPath,"lib", "libsecp256k1.a");
-		}
-
-		if (Target.Platform == UnrealTargetPlatform.Mac)
+		if (Target.Platform == UnrealTargetPlatform.Linux 
+		    || Target.Platform == UnrealTargetPlatform.LinuxArm64 
+		    || Target.Platform == UnrealTargetPlatform.Mac)
 		{
 			return Path.Combine(ThirdPartyPath,"lib", "libsecp256k1.a");
 		}


### PR DESCRIPTION
Support LinuxArm64 so that Unreal games with web3.unreal can package to that target

#### Outstanding Issues
The existing Bitcoin secp256k1.a library is not compatible with LinuxArm64.